### PR TITLE
Fix gzipped FASTQ parallel processing issue (#3)

### DIFF
--- a/src/fileio.jl
+++ b/src/fileio.jl
@@ -83,13 +83,27 @@ function write_fastq(f::Function, filepath::String)
     end
 end
 
+function count_fastq_lines(file::String)
+    total_lines = 0
+    if endswith(lowercase(file), ".gz")
+        open(GzipDecompressorStream, file, "r") do io
+            for _ in eachline(io)
+                total_lines += 1
+            end
+        end
+    else
+        total_lines = countlines(file)
+    end
+    return total_lines
+end
+
 """
 Divides a pair of FASTQ files into smaller parts for parallel processing.
 It calculates the number of reads per worker and uses the split command to divide the files.
 """
 function divide_fastq(FASTQ_file1::String, FASTQ_file2::String, output_dir::String, workers::Int, gzip_output::Bool)
 	divided_dir = mktempdir(output_dir)
-	total_lines = countlines(FASTQ_file1)
+	total_lines = count_fastq_lines(FASTQ_file1)
 	total_reads = total_lines ÷ 4
 	reads_per_worker = cld(total_reads, workers)
 	lines_per_worker = reads_per_worker * 4
@@ -123,7 +137,7 @@ Divides a single FASTQ file for parallel processing.
 """
 function divide_fastq(FASTQ_file::String, output_dir::String, workers::Int, gzip_output::Bool)
 	divided_dir = mktempdir(output_dir)
-	total_lines = countlines(FASTQ_file)
+	total_lines = count_fastq_lines(FASTQ_file)
 	total_reads = total_lines ÷ 4
 	reads_per_worker = cld(total_reads, workers)
 	lines_per_worker = reads_per_worker * 4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,39 +1,42 @@
 using BioDemuX
 using Test
 using Distributed
+using CodecZlib
 
 function check_output_files(output_dir::String, ideal_dir::String)
-    ideal_files = readdir(ideal_dir)
-
-    for ideal_file in ideal_files
+    for ideal_file in readdir(ideal_dir)
         output_file_path = joinpath(output_dir, ideal_file)
         ideal_file_path = joinpath(ideal_dir, ideal_file)
-
         @test isfile(output_file_path)
         @test isfile(ideal_file_path)
-
-        diff_result = readchomp(`diff $output_file_path $ideal_file_path`)
-        @test diff_result == ""
+        
+        if endswith(lowercase(ideal_file), ".gz")
+            output_content = read(GzipDecompressorStream(open(output_file_path)), String)
+            ideal_content = read(GzipDecompressorStream(open(ideal_file_path)), String)
+        else
+            output_content = read(output_file_path, String)
+            ideal_content = read(ideal_file_path, String)
+        end
+        
+        @test output_content == ideal_content
     end
 end
 
 @testset "Single Thread Tests" begin
-    @testset "Single thread with 1 FASTQ file" begin
+    @testset "Single thread with 1 FASTQ file (plain text)" begin
         mktempdir() do output_dir
             ideal_dir = "results/demo1_R1"
-
             files = readdir("FASTQ_files/demo1_R1")
             for file in files
-                execute_demultiplexing("FASTQ_files/demo1_R1/$file", "reference_files/demo1.tsv", output_dir)
+                execute_demultiplexing("FASTQ_files/demo1_R1/$file", "reference_files/demo1.tsv", output_dir,)
             end
             check_output_files(output_dir, ideal_dir)
         end
     end
 
-    @testset "Single thread with 2 FASTQ files" begin
+    @testset "Single thread with 2 FASTQ files (paired, plain text)" begin
         mktempdir() do output_dir
             ideal_dir = "results/demo1_R2"
-
             files_R1 = readdir("FASTQ_files/demo1_R1")
             files_R2 = readdir("FASTQ_files/demo1_R2")
             for (file_R1, file_R2) in zip(files_R1, files_R2)
@@ -42,31 +45,36 @@ end
             check_output_files(output_dir, ideal_dir)
         end
     end
-    # @testset "Single thread with 2 FASTQ files with options" begin
-    #     mktempdir() do output_dir
-    #         ideal_dir = "results/demo2"
 
-    #         files_R1 = readdir("FASTQ_files/demo2_R1")
-    #         files_R2 = readdir("FASTQ_files/demo2_R2")
-    #         for (file_R1, file_R2) in zip(files_R1, files_R2)
-    #             filename = replace(basename(file_R1), r"\.fastq.gz$" => "")
-    #             filename2 = replace(basename(file_R2), r"\.fastq.gz$" => "")
-    #             execute_demultiplexing("FASTQ_files/demo2_R1/$file_R1", "FASTQ_files/demo2_R2/$file_R2", "reference_files/demo2.csv", output_dir,
-    #                 max_error_rate=0.25, min_delta=0.15, mismatch=1, indel=2, classify_both=true, bc_complement=true, bc_rev=true,
-    #                 output_prefix1="test_prefix1." * filename, output_prefix2="test_prefix2." * filename2)
-    #         end
-    #         check_output_files(output_dir, ideal_dir)
-    #     end
-    # end
+    @testset "Single thread with 2 FASTQ file (paired, gzipped, with options)" begin
+        mktempdir() do output_dir
+            ideal_dir = "results/demo2"
+            files_R1 = readdir("FASTQ_files/demo2_R1")
+            files_R2 = readdir("FASTQ_files/demo2_R2")
+            for (file_R1, file_R2) in zip(files_R1, files_R2)
+                filename_R1 = replace(basename(file_R1), r"\.fastq\.gz$" => "")
+                filename_R2 = replace(basename(file_R2), r"\.fastq\.gz$" => "")
+                execute_demultiplexing("FASTQ_files/demo2_R1/$file_R1",
+                                       "FASTQ_files/demo2_R2/$file_R2",
+                                       "reference_files/demo2.csv", output_dir;
+                                       max_error_rate=0.25, min_delta=0.15,
+                                       mismatch=1, indel=2,
+                                       classify_both=true, bc_complement=true, bc_rev=true,
+                                       output_prefix1="test_prefix1.$filename_R1",
+                                       output_prefix2="test_prefix2.$filename_R2",
+                                       gzip_output=false)
+            end
+            check_output_files(output_dir, ideal_dir)
+        end
+    end
 end
 
 addprocs(3)
 @everywhere using BioDemuX
 @testset "Multi Thread Tests" begin
-    @testset "Multi-thread with 1 FASTQ file" begin
+    @testset "Multi-thread with 1 FASTQ file (plain text)" begin
         mktempdir() do output_dir
             ideal_dir = "results/demo1_R1"
-
             files = readdir("FASTQ_files/demo1_R1")
             for file in files
                 execute_demultiplexing("FASTQ_files/demo1_R1/$file", "reference_files/demo1.tsv", output_dir)
@@ -75,14 +83,35 @@ addprocs(3)
         end
     end
 
-    @testset "Multi-thread with 2 FASTQ files" begin
+    @testset "Multi-thread with 2 FASTQ files (paired, plain text)" begin
         mktempdir() do output_dir
             ideal_dir = "results/demo1_R2"
-
             files_R1 = readdir("FASTQ_files/demo1_R1")
             files_R2 = readdir("FASTQ_files/demo1_R2")
             for (file_R1, file_R2) in zip(files_R1, files_R2)
                 execute_demultiplexing("FASTQ_files/demo1_R1/$file_R1", "FASTQ_files/demo1_R2/$file_R2", "reference_files/demo1.tsv", output_dir)
+            end
+            check_output_files(output_dir, ideal_dir)
+        end
+    end
+
+    @testset "Multi-thread with 2 FASTQ files (paired, gzip, with options)" begin
+        mktempdir() do output_dir
+            ideal_dir = "results/demo2"
+            files_R1 = readdir("FASTQ_files/demo2_R1")
+            files_R2 = readdir("FASTQ_files/demo2_R2")
+            for (file_R1, file_R2) in zip(files_R1, files_R2)
+                filename_R1 = replace(basename(file_R1), r"\.fastq\.gz$" => "")
+                filename_R2 = replace(basename(file_R2), r"\.fastq\.gz$" => "")
+                execute_demultiplexing("FASTQ_files/demo2_R1/$file_R1",
+                                       "FASTQ_files/demo2_R2/$file_R2",
+                                       "reference_files/demo2.csv", output_dir;
+                                       max_error_rate=0.25, min_delta=0.15,
+                                       mismatch=1, indel=2,
+                                       classify_both=true, bc_complement=true, bc_rev=true,
+                                       output_prefix1="test_prefix1.$filename_R1",
+                                       output_prefix2="test_prefix2.$filename_R2",
+                                       gzip_output=false)
             end
             check_output_files(output_dir, ideal_dir)
         end


### PR DESCRIPTION
This PR fixes the issue reported in #3, where gzipped FASTQ files were not correctly processed during parallel demultiplexing, leading to incomplete read processing. And adds dedicated test cases for gzipped FASTQ processing, ensuring correctness in both single-threaded and multi-threaded scenarios.
- Closes #3