### PR TITLE
Update min_delta default to 0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ BioDemuX.jl skips calculation of unnecessary path in DP matrix based on the sett
 The `execute_demultiplexing` function provides several optional parameters to control the demultiplexing process:
 
 ```julia
-execute_demultiplexing(FASTQ_file, barcode_file, output_directory, output_prefix="", max_error_rate=0.2, min_delta=0.1, mismatch=1, indel=1, classify_both=false, bc_complement=false, bc_rev=false)
+execute_demultiplexing(FASTQ_file, barcode_file, output_directory, output_prefix="", max_error_rate=0.2, min_delta=0.0, mismatch=1, indel=1, classify_both=false, bc_complement=false, bc_rev=false)
 ```
 
 - **`max_error_rate::Float64`** (default: `0.2`): 
   - This is the maximum allowed error rate for matching sequences to barcodes. It is multiplied by the barcode's length to calculate the total penalty score that can be tolerated. If the sequence's alignment penalty exceeds this limit for all barcodes, it will be saved in `unknown.fastq`.
 
-- **`min_delta::Float64`** (default: `0.1`): 
+- **`min_delta::Float64`** (default: `0.0`): 
   - This defines the minimum difference in penalty scores needed to confidently assign a sequence to a barcode. It is multiplied by the barcode's length to determine the score difference required to avoid ambiguity. If the difference between the best match's penalty score and the second-best match's score is less than this threshold, the sequence is considered ambiguous and saved in `ambiguous_classification.fastq`.
   
 - **`mismatch::Int`** (default: `1`): 

--- a/src/core.jl
+++ b/src/core.jl
@@ -2,7 +2,7 @@
 Orchestrates the entire demultiplexing process for FASTQ files.
 Handles the preprocessing, dividing, demultiplexing, and merging of files.
 """
-function execute_demultiplexing(FASTQ_file1::String, FASTQ_file2::String, bc_file::String, output_dir::String; output_prefix1::String = "", output_prefix2::String = "", gzip_output::Union{Nothing, Bool} = nothing, max_error_rate::Float64 = 0.2, min_delta::Float64 = 0.1, mismatch::Int = 1, indel::Int = 1, classify_both::Bool = false, bc_complement::Bool = false, bc_rev::Bool = false)
+function execute_demultiplexing(FASTQ_file1::String, FASTQ_file2::String, bc_file::String, output_dir::String; output_prefix1::String = "", output_prefix2::String = "", gzip_output::Union{Nothing, Bool} = nothing, max_error_rate::Float64 = 0.2, min_delta::Float64 = 0.0, mismatch::Int = 1, indel::Int = 1, classify_both::Bool = false, bc_complement::Bool = false, bc_rev::Bool = false)
 	if !isdir(output_dir)
 		mkdir(output_dir)
 	end
@@ -41,7 +41,7 @@ function execute_demultiplexing(FASTQ_file1::String, FASTQ_file2::String, bc_fil
 	end
 end
 
-function execute_demultiplexing(FASTQ_file::String, bc_file::String, output_dir::String; output_prefix::String = "", gzip_output::Union{Nothing, Bool} = nothing, max_error_rate::Float64 = 0.2, min_delta::Float64 = 0.1, mismatch::Int = 1, indel::Int = 1, bc_complement::Bool = false, bc_rev::Bool = false)
+function execute_demultiplexing(FASTQ_file::String, bc_file::String, output_dir::String; output_prefix::String = "", gzip_output::Union{Nothing, Bool} = nothing, max_error_rate::Float64 = 0.2, min_delta::Float64 = 0.0, mismatch::Int = 1, indel::Int = 1, bc_complement::Bool = false, bc_rev::Bool = false)
 	if !isdir(output_dir)
 		mkdir(output_dir)
 	end


### PR DESCRIPTION
This PR changes the default value of `min_delta` parameter from `0.1` (previous default) to `0.0`.
The `min_delta` parameter was originally intended to avoid ambiguous barcode assignments by requiring a minimum difference in alignment scores between the best and second-best barcode matches. However, enforcing this threshold does not consistently improve demultiplexing accuracy and can unnecessarily label reads as ambiguous. 
Therefore, we have decided to change the default setting to `min_delta = 0.0`, effectively disabling the delta check by default. Users still retain the option to set `min_delta` explicitly if they wish to enforce stricter assignment criteria.