### PR TITLE
Add BufferedStreams support for efficient FASTQ file handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,17 @@ authors = ["I.Mihara <issei.mihara@xforestx.com> and contributors"]
 version = "1.1.0"
 
 [deps]
+BufferedStreams = "e1450e63-4bb3-523b-b2a4-4ffa8c0fd77d"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 
 [compat]
-julia = "1.10"
-DataFrames = "1.7"
 CSV = "0.10"
 CodecZlib = "0.7"
+DataFrames = "1.7"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/BioDemuX.jl
+++ b/src/BioDemuX.jl
@@ -6,6 +6,8 @@ export
 	semiglobal_alignment,
 	find_best_matching_bc,
 	determine_filename,
+	get_fastq_io,
+	close_all_fastq_ios,
 	write_fastq_entry,
 	classify_sequences,
 
@@ -18,7 +20,7 @@ export
 	execute_demultiplexing
 
 
-using DataFrames, CSV, Distributed, CodecZlib
+using DataFrames, CSV, Distributed, CodecZlib, BufferedStreams
 include("classification.jl")
 include("fileio.jl")
 include("core.jl")


### PR DESCRIPTION
This PR resolves the disk-write slowdown detailed in #7 by integrating BufferedStreams.jl, eliminating the costly IOStream close flush.
- Closes #7