### PR TITLE
Add dual barcoding support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ BioDemuX.jl skips calculation of unnecessary path in DP matrix based on the sett
 The `execute_demultiplexing` function provides several optional parameters to control the demultiplexing process:
 
 ```julia
-execute_demultiplexing(FASTQ_file, barcode_file, output_directory, output_prefix="", gzip_output=nothing, max_error_rate=0.2, min_delta=0.0, mismatch=1, indel=1, nindel=nothing, classify_both=false, bc_complement=false, bc_rev=false, ref_search_range="1:end", barcode_start_range="1:end", barcode_end_range="1:end", chunk_size=4000, channel_capacity=64)
+execute_demultiplexing(FASTQ_file, barcode_file, output_directory; barcode_file2=nothing, output_prefix="", gzip_output=nothing, max_error_rate=0.2, min_delta=0.0, mismatch=1, indel=1, nindel=nothing, bc_complement=false, bc_rev=false, ref_search_range="1:end", barcode_start_range="1:end", barcode_end_range="1:end", ref_search_range2="1:end", barcode_start_range2="1:end", barcode_end_range2="1:end", chunk_size=4000, channel_capacity=64)
 ```
 
 - **`max_error_rate::Float64`** (default: `0.2`): 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,18 @@ execute_demultiplexing(FASTQ_file, barcode_file, output_directory, output_prefix
 - **`channel_capacity::Int`** (default: `64`):
   - Specifies the capacity of the input/output channels. The recycle channel capacity is automatically set to `2 * channel_capacity`. Increasing this value can improve throughput on systems with high memory availability.
 
+- **`barcode_file2::Union{String, Nothing}`** (default: `nothing`):
+  - Specifies the path to the second barcode reference file for dual-index demultiplexing. If provided, the function performs a two-step alignment: first against `barcode_file`, then against `barcode_file2`.
+
+- **`ref_search_range2::String`** (default: `"1:end"`):
+  - Specifies the search range for the second barcode. Format is the same as `ref_search_range`.
+
+- **`barcode_start_range2::String`** (default: `"1:end"`):
+  - Specifies the allowed start range for the second barcode. Format is the same as `barcode_start_range`.
+
+- **`barcode_end_range2::String`** (default: `"1:end"`):
+  - Specifies the allowed end range for the second barcode. Format is the same as `barcode_end_range`.
+
 ## Example: How Barcode Length and Option Values Affect Classification
 
 We assume the case where barcode length is 10, `max_error_rate ` is 0.2, `min_delta` is 0.2, `mismatch` is 1, `indel` is 2.

--- a/src/core.jl
+++ b/src/core.jl
@@ -238,9 +238,6 @@ function execute_demultiplexing(
     ref_search_range::String="1:end",
     barcode_start_range::String="1:end",
     barcode_end_range::String="1:end",
-    ref_search_range1::String="1:end",
-    barcode_start_range1::String="1:end",
-    barcode_end_range1::String="1:end",
     ref_search_range2::String="1:end",
     barcode_start_range2::String="1:end",
     barcode_end_range2::String="1:end",
@@ -252,11 +249,6 @@ function execute_demultiplexing(
     if !isdir(output_directory)
         mkdir(output_directory)
     end
-
-    # If ref_search_range is not default ("1:end") and ref_search_range1 is default, use ref_search_range
-    rsr1 = (ref_search_range != "1:end" && ref_search_range1 == "1:end") ? ref_search_range : ref_search_range1
-    bsr1 = (barcode_start_range != "1:end" && barcode_start_range1 == "1:end") ? barcode_start_range : barcode_start_range1
-    ber1 = (barcode_end_range != "1:end" && barcode_end_range1 == "1:end") ? barcode_end_range : barcode_end_range1
 
     bc_seqs, bc_lengths_no_N, ids = preprocess_bc_file(barcode_file, bc_complement, bc_rev)
 
@@ -289,9 +281,9 @@ function execute_demultiplexing(
         nindel=nindel,
         classify_both=classify_both,
         gzip_output=gzip_output,
-        ref_search_range=parse_dynamic_range(rsr1),
-        barcode_start_range=parse_dynamic_range(bsr1),
-        barcode_end_range=parse_dynamic_range(ber1),
+        ref_search_range=parse_dynamic_range(ref_search_range),
+        barcode_start_range=parse_dynamic_range(barcode_start_range),
+        barcode_end_range=parse_dynamic_range(barcode_end_range),
         bc_seqs=bc_seqs,
         bc_lengths_no_N=bc_lengths_no_N,
         ids=ids,
@@ -355,9 +347,6 @@ function execute_demultiplexing(
     ref_search_range::String="1:end",
     barcode_start_range::String="1:end",
     barcode_end_range::String="1:end",
-    ref_search_range1::String="1:end",
-    barcode_start_range1::String="1:end",
-    barcode_end_range1::String="1:end",
     ref_search_range2::String="1:end",
     barcode_start_range2::String="1:end",
     barcode_end_range2::String="1:end",
@@ -369,10 +358,6 @@ function execute_demultiplexing(
     if !isdir(output_directory)
         mkdir(output_directory)
     end
-
-    rsr1 = (ref_search_range != "1:end" && ref_search_range1 == "1:end") ? ref_search_range : ref_search_range1
-    bsr1 = (barcode_start_range != "1:end" && barcode_start_range1 == "1:end") ? barcode_start_range : barcode_start_range1
-    ber1 = (barcode_end_range != "1:end" && barcode_end_range1 == "1:end") ? barcode_end_range : barcode_end_range1
 
     bc_seqs, bc_lengths_no_N, ids = preprocess_bc_file(barcode_file, bc_complement, bc_rev)
 
@@ -402,9 +387,9 @@ function execute_demultiplexing(
         nindel=nindel,
         classify_both=false,
         gzip_output=gzip_output,
-        ref_search_range=parse_dynamic_range(rsr1),
-        barcode_start_range=parse_dynamic_range(bsr1),
-        barcode_end_range=parse_dynamic_range(ber1),
+        ref_search_range=parse_dynamic_range(ref_search_range),
+        barcode_start_range=parse_dynamic_range(barcode_start_range),
+        barcode_end_range=parse_dynamic_range(barcode_end_range),
         bc_seqs=bc_seqs,
         bc_lengths_no_N=bc_lengths_no_N,
         ids=ids,

--- a/test/run_subprocess.jl
+++ b/test/run_subprocess.jl
@@ -4,3 +4,4 @@ using CodecZlib
 
 include("common.jl")
 include("integration_tests.jl")
+include("test_dual_index.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ println("Running tests with $(Threads.nthreads()) threads")
 
 @testset "Integration Tests (Current Process)" begin
     include("integration_tests.jl")
+    include("test_dual_index.jl")
 end
 
 if Threads.nthreads() == 1

--- a/test/test_dual_index.jl
+++ b/test/test_dual_index.jl
@@ -1,0 +1,96 @@
+using BioDemuX
+using Test
+using CodecZlib
+
+@testset "Dual Index Demultiplexing" begin
+    # Create temporary files
+    tmp_dir = mktempdir()
+
+    # 1. Create Barcode Files
+    # BC1: AAAA, CCCC
+    # BC2: TTTT, GGGG
+    bc_file1 = joinpath(tmp_dir, "bc1.tsv")
+    open(bc_file1, "w") do io
+        println(io, "Full_seq\tID\tFull_annotation")
+        println(io, "AAAA\tID1_A\tBBBB")
+        println(io, "CCCC\tID1_C\tBBBB")
+    end
+
+    bc_file2 = joinpath(tmp_dir, "bc2.tsv")
+    open(bc_file2, "w") do io
+        println(io, "Full_seq\tID\tFull_annotation")
+        println(io, "TTTT\tID2_T\tBBBB")
+        println(io, "GGGG\tID2_G\tBBBB")
+    end
+
+    # 2. Create FASTQ File
+    # Read 1: [BC1] [Linker] [BC2] [Seq]
+    # BC1 (4bp), Linker (4bp), BC2 (4bp)
+    # R1: AAAA TATA TTTT ACGT... -> ID1_A.ID2_T
+    # R2: CCCC TATA GGGG ACGT... -> ID1_C.ID2_G
+    # R3: AAAA TATA GGGG ACGT... -> ID1_A.ID2_G
+    # R4: AAAA TATA AAAA ACGT... -> Unknown (BC2 mismatch)
+
+    fastq_file = joinpath(tmp_dir, "test.fastq")
+    open(fastq_file, "w") do io
+        # Read 1
+        println(io, "@read1")
+        println(io, "AAAATATATTTTACGT")
+        println(io, "+")
+        println(io, "IIIIIIIIIIIIIIII")
+
+        # Read 2
+        println(io, "@read2")
+        println(io, "CCCCTATAGGGGACGT")
+        println(io, "+")
+        println(io, "IIIIIIIIIIIIIIII")
+
+        # Read 3
+        println(io, "@read3")
+        println(io, "AAAATATAGGGGACGT")
+        println(io, "+")
+        println(io, "IIIIIIIIIIIIIIII")
+
+        # Read 4 (Unknown)
+        println(io, "@read4")
+        println(io, "AAAATATAAAAAACGT")
+        println(io, "+")
+        println(io, "IIIIIIIIIIIIIIII")
+    end
+
+    output_dir = joinpath(tmp_dir, "output")
+    mkdir(output_dir)
+
+    # 3. Execute Demultiplexing
+    # BC1: 1:4
+    # BC2: 9:12 (4+4+1 = 9)
+
+    BioDemuX.execute_demultiplexing(
+        fastq_file,
+        bc_file1,
+        output_dir;
+        barcode_file2=bc_file2,
+        ref_search_range1="1:4",
+        ref_search_range2="9:12",
+        max_error_rate=0.0,
+        chunk_size=100
+    )
+
+    # 4. Verify Outputs
+    # Expected files: test.ID1_A.ID2_T.fastq, test.ID1_C.ID2_G.fastq, test.ID1_A.ID2_G.fastq, test.unknown.fastq
+
+    @test isfile(joinpath(output_dir, "test.ID1_A.ID2_T.fastq"))
+    @test isfile(joinpath(output_dir, "test.ID1_C.ID2_G.fastq"))
+    @test isfile(joinpath(output_dir, "test.ID1_A.ID2_G.fastq"))
+    @test isfile(joinpath(output_dir, "test.unknown.fastq"))
+
+    # Check content of ID1_A.ID2_T.fastq (should contain read1)
+    content = read(joinpath(output_dir, "test.ID1_A.ID2_T.fastq"), String)
+    @test occursin("@read1", content)
+
+    # Check content of unknown.fastq (should contain read4)
+    content_unknown = read(joinpath(output_dir, "test.unknown.fastq"), String)
+    @test occursin("@read4", content_unknown)
+
+    rm(tmp_dir, recursive=true)
+end

--- a/test/test_dual_index.jl
+++ b/test/test_dual_index.jl
@@ -70,7 +70,7 @@ using CodecZlib
         bc_file1,
         output_dir;
         barcode_file2=bc_file2,
-        ref_search_range1="1:4",
+        ref_search_range="1:4",
         ref_search_range2="9:12",
         max_error_rate=0.0,
         chunk_size=100


### PR DESCRIPTION
- Add support for providing two barcode files (primary and secondary)
- Perform two-pass alignment (bc1 → bc2) and propagate matched IDs
- Classify reads based on (barcode1, barcode2) combinations
- Single-barcode mode remains unchanged