### PR TITLE
Add Hamming-distance matching mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,16 @@ BioDemuX.jl skips calculation of unnecessary path in DP matrix based on the sett
 The `execute_demultiplexing` function provides several optional parameters to control the demultiplexing process:
 
 ```julia
-execute_demultiplexing(FASTQ_file, barcode_file, output_directory; barcode_file2=nothing, output_prefix="", gzip_output=nothing, max_error_rate=0.2, min_delta=0.0, mismatch=1, indel=1, nindel=nothing, bc_complement=false, bc_rev=false, ref_search_range="1:end", barcode_start_range="1:end", barcode_end_range="1:end", ref_search_range2="1:end", barcode_start_range2="1:end", barcode_end_range2="1:end", chunk_size=4000, channel_capacity=64)
+execute_demultiplexing(FASTQ_file, barcode_file, output_directory; barcode_file2=nothing, output_prefix="", gzip_output=nothing, max_error_rate=0.2, min_delta=0.0, mismatch=1, indel=1, nindel=nothing, bc_complement=false, bc_rev=false, ref_search_range="1:end", barcode_start_range="1:end", barcode_end_range="1:end", ref_search_range2="1:end", barcode_start_range2="1:end", barcode_end_range2="1:end", chunk_size=4000, channel_capacity=64, matching_algorithm=:semiglobal)
 ```
 
 - **`max_error_rate::Float64`** (default: `0.2`): 
   - This is the maximum allowed error rate for matching sequences to barcodes. It is multiplied by the barcode's length to calculate the total penalty score that can be tolerated. If the sequence's alignment penalty exceeds this limit for all barcodes, it will be saved in `unknown.fastq`.
+
+- **`matching_algorithm::Symbol`** (default: `:semiglobal`):
+  - Specifies the algorithm used for barcode matching.
+    - `:semiglobal`: Uses semi-global alignment allowing for mismatches, insertions, and deletions. This is the default and most robust mode.
+    - `:hamming`: Uses Hamming distance, allowing only for mismatches (no insertions or deletions). This mode is significantly faster but less robust to indel errors. Use this if your data quality is high or if speed is critical.
 
 - **`min_delta::Float64`** (default: `0.0`): 
   - This defines the minimum difference in penalty scores needed to confidently assign a sequence to a barcode. It is multiplied by the barcode's length to determine the score difference required to avoid ambiguity. If the difference between the best match's penalty score and the second-best match's score is less than this threshold, the sequence is considered ambiguous and saved in `ambiguous_classification.fastq`.

--- a/src/core.jl
+++ b/src/core.jl
@@ -302,7 +302,8 @@ function execute_demultiplexing(
     trim_side::Union{Int,Nothing}=nothing,
     trim_side2::Union{Int,Nothing}=nothing,
     summary::Bool=false,
-    summary_format::Symbol=:html
+    summary_format::Symbol=:html,
+    matching_algorithm::Symbol=:semiglobal
 )
 
     # Validate trim_side
@@ -362,7 +363,8 @@ function execute_demultiplexing(
         trim_side=trim_side,
         trim_side2=trim_side2,
         summary=summary,
-        summary_format=summary_format
+        summary_format=summary_format,
+        matching_algorithm=matching_algorithm
     )
 
     # Channels
@@ -451,7 +453,8 @@ function execute_demultiplexing(
     trim_side::Union{Int,Nothing}=nothing,
     trim_side2::Union{Int,Nothing}=nothing,
     summary::Bool=false,
-    summary_format::Symbol=:html
+    summary_format::Symbol=:html,
+    matching_algorithm::Symbol=:semiglobal
 )
 
     # Validate trim_side
@@ -511,7 +514,8 @@ function execute_demultiplexing(
         trim_side=trim_side,
         trim_side2=trim_side2,
         summary=summary,
-        summary_format=summary_format
+        summary_format=summary_format,
+        matching_algorithm=matching_algorithm
     )
 
     # Channels

--- a/test/integration/hamming_demux.jl
+++ b/test/integration/hamming_demux.jl
@@ -1,0 +1,77 @@
+@testset "Hamming Distance Integration" begin
+    # Test Single End, Hamming Mode
+    @testset "Single End Hamming" begin
+        mktempdir() do output_dir
+            # Create barcodes
+            bc_file = joinpath(output_dir, "barcodes.csv")
+            open(bc_file, "w") do io
+                println(io, "ID,Full_seq,Full_annotation")
+                println(io, "BC1,ACGTAC,BBBBBB")
+                println(io, "BC2,CCCCCC,BBBBBB")
+            end
+
+            # Create Reads
+            fastq_file = joinpath(output_dir, "reads.fastq")
+            open(fastq_file, "w") do io
+                write(io, "@read1\nACGTAC\n+\nIIIIII\n") # Perfect BC1
+                write(io, "@read2\nCCCCCC\n+\nIIIIII\n") # Perfect BC2
+                write(io, "@read3\nACATAC\n+\nIIIIII\n") # 1 mismatch BC1 (A vs G) -> Score 1/6 = 0.166 <= 0.2. Match.
+                write(io, "@read4\nACGTAG\n+\nIIIIII\n") # 1 mismatch BC1 (G vs C) -> Score 1/6 = 0.166 <= 0.2. Match.
+                write(io, "@read_indel\nACGGTAC\n+\nIIIIIII\n") # Insertion G. "ACGTAC" vs "ACGGTAC".
+                # Pos 1: A-A(m), C-C(m), G-G(m), T-G(mis), A-T(mis), C-A(mis). 3 mismatches. Score 0.5 > 0.2. Fail.
+            end
+
+            BioDemuX.execute_demultiplexing(
+                fastq_file, bc_file, output_dir,
+                matching_algorithm=:hamming,
+                max_error_rate=0.2
+            )
+
+            @test isfile(joinpath(output_dir, "reads.BC1.fastq"))
+            @test isfile(joinpath(output_dir, "reads.BC2.fastq"))
+            @test isfile(joinpath(output_dir, "reads.unknown.fastq"))
+
+            # Count lines
+            count_lines(f) = count(_ -> true, eachline(f))
+
+            # BC1: read1, read3, read4 -> 12 lines
+            @test count_lines(joinpath(output_dir, "reads.BC1.fastq")) == 12
+            # BC2: read2 -> 4 lines
+            @test count_lines(joinpath(output_dir, "reads.BC2.fastq")) == 4
+            # Unknown: read_indel -> 4 lines
+            @test count_lines(joinpath(output_dir, "reads.unknown.fastq")) == 4
+        end
+    end
+
+    # Test Paired End, Hamming Mode
+    @testset "Paired End Hamming" begin
+        mktempdir() do output_dir
+            bc_file = joinpath(output_dir, "barcodes.csv")
+            open(bc_file, "w") do io
+                println(io, "ID,Full_seq,Full_annotation")
+                println(io, "BC1,AAAA,BBBB")
+            end
+
+            # Create Dummy Paired Reads
+            fq1 = joinpath(output_dir, "R1.fastq")
+            fq2 = joinpath(output_dir, "R2.fastq")
+
+            open(fq1, "w") do io
+                write(io, "@seq1\nAAAA\n+\nIIII\n")
+            end
+            open(fq2, "w") do io
+                write(io, "@seq1\nGGGG\n+\nIIII\n")
+            end
+
+            BioDemuX.execute_demultiplexing(
+                fq1, fq2, bc_file, output_dir,
+                matching_algorithm=:hamming,
+                max_error_rate=0.0,
+                classify_both=true
+            )
+
+            @test isfile(joinpath(output_dir, "R1.BC1.fastq"))
+            @test isfile(joinpath(output_dir, "R2.BC1.fastq"))
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ include("common.jl")
 @testset "Unit Tests" begin
     include("unit/alignment.jl")
     include("unit/trimming.jl")
+    include("unit/hamming.jl")
 end
 
 println("Running tests with $(Threads.nthreads()) threads")
@@ -15,7 +16,9 @@ println("Running tests with $(Threads.nthreads()) threads")
     include("integration/single_barcode.jl")
     include("integration/dual_barcode.jl")
     include("integration/summary_mode.jl")
+
     include("integration/summary_distributions.jl")
+    include("integration/hamming_demux.jl")
 end
 
 if Threads.nthreads() == 1

--- a/test/unit/hamming.jl
+++ b/test/unit/hamming.jl
@@ -1,0 +1,56 @@
+
+@testset "Hamming Alignment" begin
+    # Test cases for hamming_align function
+    # Correct signature: hamming_align(query, ref, max_error_rate, ref_search_range, max_start_pos, min_end_pos, trim_side)
+
+    # 1. Exact match
+    q = "AAAA"
+    r = "TTAAAAgg"
+    # Search range effectively covering everything
+    res = BioDemuX.hamming_align(q, r, 0.2, 1:length(r), length(r), 1, nothing)
+    @test res == (0.0, 3, 6)
+
+    # 2. One mismatch (allowed)
+    q = "AAAA"
+    r = "TTAATAgg" # "AATA" vs "AAAA" -> 1 mismatch / 4 = 0.25. If max_error=0.3, should pass
+    res = BioDemuX.hamming_align(q, r, 0.3, 1:length(r), length(r), 1, nothing)
+    @test res == (0.25, 3, 6)
+
+    # 3. Mismatch exceeding error rate
+    res = BioDemuX.hamming_align(q, r, 0.2, 1:length(r), length(r), 1, nothing)
+    @test res == (Inf, -1, -1)
+
+    # 4. 'N' in query (wildcard)
+    q = "ANNA"
+    r = "TTAATAgg" # "AATA" vs "ANNA" -> match, match, match, match (N matches anything)
+    res = BioDemuX.hamming_align(q, r, 0.0, 1:length(r), length(r), 1, nothing)
+    @test res == (0.0, 3, 6)
+
+    # 5. 'N' in reference (mismatch unless query is 'N')
+    q = "AAAA"
+    r = "TTANAAgg" # "ANAA" vs "AAAA" -> N in ref is not wildcard for A
+    # If N in ref does not match A in query, it's a mismatch. 
+    # Current implementation: if q_char != r_char && q_char != 'N', mismatch.
+    # So 'A' != 'N' -> mismatch.
+    res = BioDemuX.hamming_align(q, r, 0.0, 1:length(r), length(r), 1, nothing)
+    @test res == (Inf, -1, -1)
+
+    # 6. Boundary conditions
+    q = "AAAA"
+    r = "AAAA"
+    res = BioDemuX.hamming_align(q, r, 0.0, 1:4, 4, 1, nothing)
+    @test res == (0.0, 1, 4)
+
+    # 7. Trimming side 3 (keep better match to the right? No, standard tie breaking)
+    # hamming_align logic: if score == best_score && trim_side == 3 && j > best_start -> update
+    # Case where same best score appears twice
+    q = "AA"
+    r = "AATAA" # Matches at 1 (AA) and 4 (AA)
+    # If trim_side=3, prefer rightmost (later start)
+    res = BioDemuX.hamming_align(q, r, 0.0, 1:5, 5, 1, 3)
+    @test res == (0.0, 4, 5)
+
+    # If trim_side=nothing or 5, prefer leftmost (first found)
+    res_def = BioDemuX.hamming_align(q, r, 0.0, 1:5, 5, 1, nothing)
+    @test res_def == (0.0, 1, 2)
+end


### PR DESCRIPTION
- Add a Hamming-distance mode for fixed-length barcodes without indels
- Use a fast path when indels are not allowed
- Expose a config option to select Hamming mode instead of DP
- Keep the existing DP-based mode available